### PR TITLE
target/xtensa: fix sample_controller32 build for QEMU 7

### DIFF
--- a/target/xtensa/core-sample_controller32.c
+++ b/target/xtensa/core-sample_controller32.c
@@ -1,6 +1,6 @@
 #include "qemu/osdep.h"
 #include "cpu.h"
-#include "gdbstub/helpers.h"
+#include "exec/gdbstub.h"
 #include "qemu/host-utils.h"
 
 #include "core-sample_controller32/core-isa.h"


### PR DESCRIPTION
The original patches for adding sample_controller32 are based on QEMU 9. The GDB stub header file is not in the same place between these two version. So fix that for QEMU 7. This can be reverted when we move to QEMU 9.